### PR TITLE
PR: ポートフォリオ詳細モーダルの画像切り替え

### DIFF
--- a/src/components/Main/Portfolio.vue
+++ b/src/components/Main/Portfolio.vue
@@ -44,7 +44,7 @@ export default {
             ],
             used: ["Vue.js"],
             thumbnail: "pf.png",
-            images: ["pf.png", "pf.png", "pf.png"],
+            images: ["pf.png", "by.png", "ttm.png"],
             github: "portfolio",
           },
           {
@@ -59,7 +59,7 @@ export default {
             ],
             used: ["PHP", "SQLite"],
             thumbnail: "by.png",
-            images: ["by.png", "by.png", "by.png"],
+            images: ["by.png", "pf.png", "ttm.png"],
             github: "ksre2",
           },
           {
@@ -74,7 +74,7 @@ export default {
             ],
             used: ["jQuery"],
             thumbnail: "ttm.png",
-            images: ["ttm.png", "ttm.png", "ttm.png"],
+            images: ["ttm.png", "pf.png", "by.png"],
             github: "time-table-maker",
           },
           {
@@ -86,7 +86,7 @@ export default {
             ],
             used: ["PDFMake"],
             thumbnail: "ipc.png",
-            images: ["ipc.png", "ipc.png", "ipc.png"],
+            images: ["ipc.png", "by.png", "pf.png"],
             github: "image-pdf-converter",
           },
           {
@@ -101,7 +101,7 @@ export default {
             ],
             used: ["PHP", "cron"],
             thumbnail: "seb.png",
-            images: ["seb.png", "seb.png", "seb.png"],
+            images: ["seb.png", "ipc.png", "vgc.png", "pf.png"],
             github: "detect-error-bot",
           },
           {
@@ -116,7 +116,7 @@ export default {
             ],
             used: ["Vue.js"],
             thumbnail: "vgc.png",
-            images: ["vgc.png", "vgc.png", "vgc.png"],
+            images: ["vgc.png", "by.png", "pf.png"],
             github: "vue-gamble-calculator",
           },
         ],

--- a/src/components/Main/PortfolioMoreDialog.vue
+++ b/src/components/Main/PortfolioMoreDialog.vue
@@ -1,22 +1,24 @@
 <template>
-  <div class="portfolio__dialog" @click="closeDialog">
+  <div class="portfolio__dialog">
+    <div class="portfolio__dialog__background" @click="closeDialog"></div>
     <div class="portfolio__dialog__container">
       <div class="portfolio__dialog__images">
         <div class="portfolio__dialog__images__show">
           <img
-            class="portfolio__dialog__images__show__item"
+            class="portfolio__dialog__images__show__item js-thumbnail"
             :src="withImage.thumbnail"
             :alt="portfolioItem.thumbnail"
           />
         </div>
         <div class="portfolio__dialog__images__list">
           <img
-            class="portfolio__dialog__images__list__item"
-            :class="{ pc: isPC }"
+            class="portfolio__dialog__images__list__item js-image"
+            :class="{ pc: isPC, selected: !key }"
             v-for="(image, key) in portfolioItem.images"
             :src="getImagePath(image)"
             :alt="image"
             :key="key"
+            @click="switchImage"
           />
         </div>
       </div>
@@ -87,12 +89,28 @@ export default {
   methods: {
     closeDialog() {
       this.$parent.showMoreDialog = false;
+      setTimeout(() => {
+        const nowSelected = document.querySelector(".selected");
+        nowSelected.classList.remove("selected");
+        const firstImage = document.querySelector(".js-image");
+        firstImage.classList.add("selected");
+        const thumbnail = document.querySelector(".js-thumbnail");
+        thumbnail.src = firstImage.src;
+      }, 300);
     },
     getImagePath(imageName) {
       return require("@/assets/images/photo/" + imageName);
     },
     getGithubUrl(repoName) {
       return `https://github.com/Maple0922/${repoName}`;
+    },
+    switchImage(e) {
+      const nowSelected = document.querySelector(".selected");
+      nowSelected.classList.remove("selected");
+      const selectedImage = e.target;
+      const thumbnail = document.querySelector(".js-thumbnail");
+      thumbnail.src = selectedImage.src;
+      selectedImage.classList.add("selected");
     },
     isSP: function () {
       return this.isMobile(window.navigator).any;
@@ -131,7 +149,6 @@ export default {
   align-items: center;
   top: 0;
   left: 0;
-  background: #0009;
   opacity: 0;
   transition: 0.3s;
   pointer-events: none;
@@ -142,6 +159,16 @@ export default {
   }
 
   // common
+  &__background {
+    width: 100%;
+    height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: #0009;
+    z-index: 7000;
+  }
+
   &__container {
     width: 84%;
     margin: 0 auto;
@@ -149,6 +176,8 @@ export default {
     border-radius: 4px;
     display: flex;
     overflow: hidden;
+    position: relative;
+    z-index: 8000;
   }
   &__images {
     display: block;
@@ -160,7 +189,7 @@ export default {
       &__item {
         width: 100%;
         object-fit: cover;
-        border-bottom: 1px solid $white;
+        border-bottom: 1px solid $super-light-gray;
       }
     }
 
@@ -169,17 +198,15 @@ export default {
       &__item {
         object-fit: cover;
         cursor: pointer;
-        border-right: 1px solid $gray;
-        border-bottom: 1px solid $gray;
-        border-top: 1px solid $gray;
+        border: 2px solid transparent;
         &.pc {
-          transition: 0.3s;
+          transition: 0.1s;
           &:hover {
-            opacity: 0.4;
+            opacity: 0.9;
           }
         }
         &.selected {
-          border: 1px solid orange;
+          border: 2px solid orange;
         }
       }
     }

--- a/src/components/Main/PortfolioMoreDialog.vue
+++ b/src/components/Main/PortfolioMoreDialog.vue
@@ -12,6 +12,7 @@
         <div class="portfolio__dialog__images__list">
           <img
             class="portfolio__dialog__images__list__item"
+            :class="{ pc: isPC }"
             v-for="(image, key) in portfolioItem.images"
             :src="getImagePath(image)"
             :alt="image"
@@ -72,10 +73,16 @@
 
 <script>
 import GithubBlackSvg from "@/assets/images/svg/github_black.svg";
+import isMobile from "ismobilejs";
 
 export default {
   name: "PortfolioMoreDialog",
   props: ["portfolioItem"],
+  data() {
+    return {
+      isMobile,
+    };
+  },
 
   methods: {
     closeDialog() {
@@ -86,6 +93,12 @@ export default {
     },
     getGithubUrl(repoName) {
       return `https://github.com/Maple0922/${repoName}`;
+    },
+    isSP: function () {
+      return this.isMobile(window.navigator).any;
+    },
+    isPC: function () {
+      return !this.isMobile(window.navigator).any;
     },
   },
 
@@ -156,9 +169,17 @@ export default {
       &__item {
         object-fit: cover;
         cursor: pointer;
-        border: 3px solid $super-light-gray;
+        border-right: 1px solid $gray;
+        border-bottom: 1px solid $gray;
+        border-top: 1px solid $gray;
+        &.pc {
+          transition: 0.3s;
+          &:hover {
+            opacity: 0.4;
+          }
+        }
         &.selected {
-          border: 3px solid orange;
+          border: 1px solid orange;
         }
       }
     }


### PR DESCRIPTION
## 対応issue
- resolve #4

## 内容
- テスト画像の挿入
- 背景クリックでモーダルが閉じるようにする
- 画像切り替えの関数
  - 画像リストの画像をクリックで発火
  - 現時点でselectedクラスがついているものから外す
  - クリックした画像のURLを取得し、thumbnailのsrcに代入
  - クリックした画像にselectedクラスを付与
→クリックした画像がthumbnailに表示され、画像リストの中ではselectedクラスを付与される

- モーダルクローズの関数
  - モーダルのbackgroundをクリックで発火
  - モーダルの表示を切り替えるMainコンポーネントの変数`showMoreDialog`をfalseに
  - .3s後、モーダルが消える
  - 閉じた時点でselectedクラスがついているものから外す
  - 画像リストの最初の画像を`querySelector`で取得
  - selectedクラスを付与
  - 最初の画像のURLを取得し、thumbnailのsrcに代入
→モーダルが閉じてから、画像リストの最初の要素にselectedクラスが付与され、thumbnailにもその画像が表示されるので、初期状態に戻る